### PR TITLE
Updating build procedure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 html
 latex
 .DS_Store
+*.h5
+*.dat
+Makefile.in
+bin/

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+MAKEFILE_IN = $(PWD)/Makefile.in
+include $(MAKEFILE_IN)
+
 APP      = disco
 
 SRCEXT   = c
@@ -5,32 +8,28 @@ SRCDIR   = src
 OBJDIR   = obj
 BINDIR   = bin
 
-UNAME = $(shell uname)
-ifeq ($(UNAME),Linux)
-H55 = /home/install/app/hdf5-1.6_intel_mpi
-#H55 = /share/apps/hdf5/1.8.2/openmpi/intel
-#GSL = /home/install/app/gsl_gcc_mpi
-#H55 = /share/apps/hdf5/1.8.2/openmpi/intel
-endif
-ifeq ($(UNAME),Darwin)
-H55 = /usr/local/
-#H55 = /opt/local/
-#GSL = /opt/local
-endif
-
 SRCS    := $(shell find $(SRCDIR) -name '*.$(SRCEXT)')
 SRCDIRS := $(shell find . -name '*.$(SRCEXT)' -exec dirname {} \; | uniq)
 OBJS    := $(patsubst %.$(SRCEXT),$(OBJDIR)/%.o,$(SRCS))
 
-DEBUG    = -g
-#INCLUDES = -I$(H55)/include -I$(GSL)/include
-INCLUDES = -I$(H55)/include
-CFLAGS   = -O3 -c $(DEBUG) $(INCLUDES)
-#CFLAGS   = -c $(DEBUG) $(INCLUDES)
-#LDFLAGS  = -lm -lz -L$(H55)/lib -L$(GSL)/lib -lhdf5 -lgsl -lgslcblas
-LDFLAGS  = -lm -lz -L$(H55)/lib -lhdf5
+#Vital flags/incs/libs 
 
+DEBUG    = -g -Wall
+OPT      = -O3
+INCLUDES = -I$(H55)/include
+CFLAGS   = -c
+LDFLAGS  = -lm -lz -L$(H55)/lib -lhdf5
 CC       = mpicc
+
+#User-set flags
+ifeq ($(strip $(USE_DEBUG)), 1)
+	CFLAGS += $(DEBUG)
+endif
+ifeq ($(strip $(USE_OPT)), 1)
+	CFLAGS += $(OPT)
+endif
+
+CFLAGS += $(INCLUDES)
 
 .PHONY: all clean distclean
 

--- a/Makefile.in.template
+++ b/Makefile.in.template
@@ -1,0 +1,11 @@
+#Makefile.in for Disco2
+
+#This file contains the user-specified build options and is machine-specific.
+
+#Location of (Parallel) HDF5 library.
+H55 = /usr/local
+
+#Compile flags
+USE_DEBUG = 1  # Compile with symbol table and all warnings
+USE_OPT   = 0  # Compile with optimization -O3.
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Output files will be written into the directory where you executed disco.
 
 ---
 
+Notes
+
 * The overall approach here is to mimic the sort of object-oriented design philosophy that you would typically get in C++, using only C. The way we do this is by organizing data and functions into categories that you can think of as "classes". Each folder in src/ is associated with a different class. Each class is composed of a structure and functions associated with that structure. We declare the structure as an incomplete type in its header file so that other classes cannot access its innards directly. See http://en.wikipedia.org/wiki/Opaque_pointer. The reason we do all this is that a new user who modifies the code is much less likely to introduce subtle bugs because they can only really modify data using pre-defined functions.
 
 * You will need to compile hdf5 with parallel support. Using macports won't give you this. I did it by simply compiling the hdf5 source using mpicc. make sure you edit the Disco Makefile according to the location of your installation.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 Disco2
 ======
 
+Build Instructions
+
+1) Copy Makefile.in.template into a new file Makefile.in.  Modify Makefile.in to accomodate your machine's layout, currently this only requires pointing it to your (parallel) HDF5 installation and setting the flags for performance or development.
+
+2) Type 'make' to compile the binary.
+
+---
+
+Run Instructions
+
+The disco binary lives in bin/.  It takes a single command-line option: a parameter file.  Example parameter files are found in parfiles/.  If you're in the top directory you can run the vortex example simply as:
+
+$ bin/disco parfiles/vortex.par
+
+Output files will be written into the directory where you executed disco.
+
+---
+
 * The overall approach here is to mimic the sort of object-oriented design philosophy that you would typically get in C++, using only C. The way we do this is by organizing data and functions into categories that you can think of as "classes". Each folder in src/ is associated with a different class. Each class is composed of a structure and functions associated with that structure. We declare the structure as an incomplete type in its header file so that other classes cannot access its innards directly. See http://en.wikipedia.org/wiki/Opaque_pointer. The reason we do all this is that a new user who modifies the code is much less likely to introduce subtle bugs because they can only really modify data using pre-defined functions.
 
 * You will need to compile hdf5 with parallel support. Using macports won't give you this. I did it by simply compiling the hdf5 source using mpicc. make sure you edit the Disco Makefile according to the location of your installation.


### PR DESCRIPTION
All user (or machine) specific options are contained in "Makefile.in", a non-version controlled include file for Makefile.  This eases portability between machines, as each machine (and user) can keep their own Makefile.in, which will not be overwritten when pulling updates from the repo.

All users will have to make their own Makefile.in before Disco will compile.  This only has to be done once, unless large code changes (like incorporating other libraries) occur.

This is in response to Issue #3 
